### PR TITLE
Polish mobile, refresh shader, About overlay & a11y pass

### DIFF
--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -113,21 +113,6 @@ const Page: FunctionComponent = () => {
         setClickData({ x: nx, y: ny, time: Date.now() });
     }, [infoOpen]);
 
-    // Long-press anywhere (mobile) opens the About overlay
-    const longPressTimer = useRef<number | undefined>(undefined);
-    const handlePointerDown = useCallback((e: React.PointerEvent) => {
-        if (e.pointerType !== 'touch' || infoOpen) return;
-        longPressTimer.current = window.setTimeout(() => {
-            setInfoOpen(true);
-        }, 650);
-    }, [infoOpen]);
-    const cancelLongPress = useCallback(() => {
-        if (longPressTimer.current) {
-            window.clearTimeout(longPressTimer.current);
-            longPressTimer.current = undefined;
-        }
-    }, []);
-
     const openInfo = useCallback(() => setInfoOpen(true), []);
     const closeInfo = useCallback(() => setInfoOpen(false), []);
 
@@ -331,10 +316,6 @@ const Page: FunctionComponent = () => {
             className="inset-0 fixed overflow-hidden cursor-crosshair"
             onClick={handleClick}
             onPointerMove={handlePointerMove}
-            onPointerDown={handlePointerDown}
-            onPointerUp={cancelLongPress}
-            onPointerCancel={cancelLongPress}
-            onPointerLeave={cancelLongPress}
         >
             {webglSupported ? (
                 <Canvas
@@ -420,13 +401,20 @@ const Page: FunctionComponent = () => {
                         </button>
                         <span className="uppercase font-normal text-xs opacity-50 text-end pointer-events-auto select-none">Press I</span>
                     </div>
-                    {/* Mobile-only About button so it's reachable without keyboard */}
-                    <div className="absolute top-0 right-0 my-6 mx-6 sm:hidden">
+                    {/* Mobile-only top bar: wordmark on the left, About on the right */}
+                    <div className="absolute top-0 left-0 right-0 flex items-center justify-between sm:hidden pointer-events-none">
+                        <a
+                            href="/"
+                            aria-label="appxpy.com home"
+                            className="uppercase font-normal text-sm pointer-events-auto relative after:duration-300 after:bg-white after:w-0 after:h-[1.5px] after:absolute after:bottom-[3.5px] after:left-0 hover:after:w-full focus-visible:outline-none focus-visible:after:w-full"
+                        >
+                            appxpy.com
+                        </a>
                         <button
                             type="button"
                             onClick={openInfo}
                             aria-label="Open about panel"
-                            className="relative uppercase font-normal text-sm text-end pointer-events-auto after:duration-300 after:bg-white after:w-0 after:h-[1.5px] after:absolute after:bottom-[3.5px] after:right-0 hover:after:w-full focus-visible:outline-none focus-visible:after:w-full"
+                            className="relative uppercase font-normal text-sm pointer-events-auto after:duration-300 after:bg-white after:w-0 after:h-[1.5px] after:absolute after:bottom-[3.5px] after:right-0 hover:after:w-full focus-visible:outline-none focus-visible:after:w-full"
                         >
                             About ↗
                         </button>
@@ -472,12 +460,12 @@ const Page: FunctionComponent = () => {
                     </nav>
 
                     <header
-                        className={'flex flex-col mm:flex-row justify-center items-center h-32 mm:h-10 gap-3 mm:gap-4 sm:gap-10 md:gap-16 select-none'}
+                        className={'flex flex-col mm:flex-row justify-center items-center pt-10 mm:pt-0 h-auto mm:h-10 gap-4 mm:gap-4 sm:gap-10 md:gap-16 select-none'}
                     >
-                        <div className="flex justify-center mm:justify-between w-min order-2 mm:order-[0] pointer-events-auto">
-                            <span className="uppercase font-normal text-lg text-center" aria-label={`Day: ${day}`}>{day}</span>
+                        <div className="flex items-center justify-center mm:justify-between gap-2 mm:gap-3 pointer-events-auto mm:w-min">
+                            <span className="uppercase font-normal text-base mm:text-lg text-center tabular-nums" aria-label={`Day: ${day}`}>{day}</span>
                             <span
-                                className="uppercase w-20 font-normal text-lg text-center hidden sm:block"
+                                className="uppercase w-20 font-normal text-lg text-center hidden sm:block tabular-nums"
                                 aria-live="off"
                                 aria-label={`Local time: ${time}`}
                             >
@@ -486,7 +474,7 @@ const Page: FunctionComponent = () => {
                         </div>
                         <Logo size={40} />
                         <a
-                            className="relative uppercase font-normal text-lg text-center w-40 pointer-events-auto hover:cursor-pointer after:duration-300 after:bg-white after:w-0 after:h-[1.5px] after:absolute after:bottom-[5.5px] after:left-1/2 after:-translate-x-1/2 hover:after:w-[9.5rem] focus-visible:outline-none focus-visible:after:w-[9.5rem]"
+                            className="relative uppercase font-normal text-base mm:text-lg text-center w-40 pointer-events-auto hover:cursor-pointer after:duration-300 after:bg-white after:w-0 after:h-[1.5px] after:absolute after:bottom-[5.5px] after:left-1/2 after:-translate-x-1/2 hover:after:w-[9.5rem] focus-visible:outline-none focus-visible:after:w-[9.5rem]"
                             href={LINKS.cv}
                             target="_blank"
                             rel="noopener"

--- a/src/shaders/shader.frag
+++ b/src/shaders/shader.frag
@@ -12,7 +12,7 @@ uniform vec2 uMouse;
 uniform float uReducedMotion; // 0.0 or 1.0
 
 // -----------------------------------------------------------------------------
-// Small hash / noise helpers
+// Hash / noise helpers
 // -----------------------------------------------------------------------------
 float hash12(vec2 p) {
     p = fract(p * vec2(123.34, 456.21));
@@ -20,7 +20,12 @@ float hash12(vec2 p) {
     return fract(p.x * p.y);
 }
 
-// Value noise for the subtle grain layer
+vec2 hash22(vec2 p) {
+    p = vec2(dot(p, vec2(127.1, 311.7)), dot(p, vec2(269.5, 183.3)));
+    return fract(sin(p) * 43758.5453123);
+}
+
+// Smoothed value noise
 float vnoise(vec2 p) {
     vec2 i = floor(p);
     vec2 f = fract(p);
@@ -32,115 +37,195 @@ float vnoise(vec2 p) {
     return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
 }
 
+// 3-octave FBM on top of value noise — adds depth to the fluid field
+float fbm(vec2 p) {
+    float v = 0.0;
+    float a = 0.5;
+    for (int i = 0; i < 3; i++) {
+        v += a * vnoise(p);
+        p *= 2.02;
+        a *= 0.5;
+    }
+    return v;
+}
+
+// Aspect-corrected UV centered at origin, shortest side ≈ 1.
+// We derive everything from vUv (plane-space [0..1]) and iResolution (CSS px),
+// so the result is DPR-independent and consistent across mouse/click/frag.
+vec2 toUV(vec2 uv01) {
+    vec2 p = (uv01 - 0.5) * iResolution.xy / min(iResolution.x, iResolution.y);
+    return p * 1.4;
+}
+
 // -----------------------------------------------------------------------------
 // Main
 // -----------------------------------------------------------------------------
 void main() {
     float motionScale = mix(1.0, 0.15, uReducedMotion);
-    float slowedTime = uTime / 15.0 * motionScale;
+    float T = uTime * 0.08 * motionScale;   // slow master clock for the field
 
-    // Normalize coords so shortest edge = 1
-    vec2 uv = (0.7 * gl_FragCoord.xy - iResolution.xy) / min(iResolution.x, iResolution.y);
+    vec2 uv = toUV(vUv);
 
     float totalGlow = 0.0;
+    vec3  glowTint  = vec3(0.0);              // accumulated colored glow
 
-    // --- Gravitational lensing around mouse ---
-    vec2 mousePixel = uMouse * iResolution.xy * uDpr;
-    vec2 mouseUV = (0.7 * mousePixel - iResolution.xy) / min(iResolution.x, iResolution.y);
-    vec2 toMouse = uv - mouseUV;
+    // ---------------------------------------------------------------------
+    // Gravitational lensing + soft chromatic halo around the cursor
+    // ---------------------------------------------------------------------
+    vec2 mouseUV    = toUV(uMouse);
+    vec2 toMouse    = uv - mouseUV;
     float mouseDist = length(toMouse);
 
-    float lensRadius = 0.8;
-    float lensStrength = 0.07 * mix(1.0, 0.3, uReducedMotion);
+    float lensRadius   = 0.9;
+    float lensStrength = 0.06 * mix(1.0, 0.3, uReducedMotion);
     if (mouseDist < lensRadius) {
         float normDist = mouseDist / lensRadius;
-        float warp = lensStrength * pow(1.0 - normDist, 2.0) / (mouseDist + 0.01);
+        float warp = lensStrength * pow(1.0 - normDist, 2.0) / (mouseDist + 0.015);
         uv -= toMouse * warp;
-        // subtle pulsing halo around cursor
-        float pulse = 0.85 + 0.15 * sin(uTime * 1.8);
-        totalGlow += pow(1.0 - normDist, 3.0) * 0.02 * pulse;
+
+        float pulse   = 0.85 + 0.15 * sin(uTime * 1.6);
+        float haloAmt = pow(1.0 - normDist, 3.0) * pulse;
+        totalGlow    += haloAmt * 0.022;
+        // cool-to-warm tint that breathes with the pulse
+        glowTint     += haloAmt * vec3(0.02, 0.035, 0.06);
     }
 
-    // --- Shockwave ripples from all active clicks ---
+    // ---------------------------------------------------------------------
+    // Shockwave ripples from clicks
+    // ---------------------------------------------------------------------
     for (int i = 0; i < MAX_RIPPLES; i++) {
         if (i >= uRippleCount) break;
 
         float elapsed = uTime - uClickTimes[i];
         if (elapsed > 2.8) continue;
 
-        float t = clamp(elapsed / 2.8, 0.0, 1.0);
+        float t     = clamp(elapsed / 2.8, 0.0, 1.0);
         float eased = 1.0 - pow(1.0 - t, 3.0);
-        float radius = eased * 1.6;
-        float fade = pow(1.0 - t, 2.0);
-        float fadeIn = smoothstep(0.0, 0.08, elapsed);
-        fade *= fadeIn;
+        float radius = eased * 1.7;
+        float fade   = pow(1.0 - t, 2.0);
+        fade *= smoothstep(0.0, 0.08, elapsed);
 
-        vec2 clickPixel = uClicks[i] * iResolution.xy * uDpr;
-        vec2 clickUV = (0.7 * clickPixel - iResolution.xy) / min(iResolution.x, iResolution.y);
-        float dist = distance(uv, clickUV);
+        vec2 clickUV = toUV(uClicks[i]);
+        float dist   = distance(uv, clickUV);
 
-        float ringWidth = 0.09 + elapsed * 0.022;
-        float ring = smoothstep(ringWidth, 0.0, abs(dist - radius));
+        float ringWidth = 0.10 + elapsed * 0.022;
+        float ring      = smoothstep(ringWidth, 0.0, abs(dist - radius));
 
-        vec2 dir = normalize(uv - clickUV + 0.0001);
-        uv += dir * ring * fade * 0.13;
-        totalGlow += ring * fade * 0.07;
+        vec2 dir  = normalize(uv - clickUV + 0.0001);
+        uv       += dir * ring * fade * 0.14;
+        totalGlow += ring * fade * 0.09;
+        glowTint  += ring * fade * vec3(0.02, 0.04, 0.08); // cool teal bloom
 
-        // Faint trailing wake behind the leading ring
-        float trail = smoothstep(radius, radius - 0.15, dist) * smoothstep(radius - 0.4, radius - 0.1, dist);
-        totalGlow += trail * fade * 0.012;
+        // Trailing wake
+        float trail = smoothstep(radius, radius - 0.18, dist)
+                    * smoothstep(radius - 0.45, radius - 0.1, dist);
+        totalGlow  += trail * fade * 0.018;
     }
 
-    // --- Core fluid field (unrolled for compile-time loop cost) ---
-    // i = 1
-    uv.x += 1.2 * cos(0.5 * uv.y + slowedTime);
-    uv.y += 0.6 * cos(1.4 * uv.x + slowedTime);
-    // i = 2
-    uv.x += 0.6 * cos(1.0 * uv.y + slowedTime);
-    uv.y += 0.3 * cos(2.8 * uv.x + slowedTime);
-    // i = 3
-    uv.x += 0.4 * cos(1.5 * uv.y + slowedTime);
-    uv.y += 0.2 * cos(4.2 * uv.x + slowedTime);
-    // i = 4
-    uv.x += 0.3 * cos(2.0 * uv.y + slowedTime);
-    uv.y += 0.15 * cos(5.6 * uv.x + slowedTime);
-    // i = 5
-    uv.x += 0.24 * cos(2.5 * uv.y + slowedTime);
-    uv.y += 0.12 * cos(7.0 * uv.x + slowedTime);
+    // ---------------------------------------------------------------------
+    // Core fluid field — unrolled domain warp modulated by slow FBM
+    // ---------------------------------------------------------------------
+    float flow = fbm(uv * 0.6 + T * 0.4) * 0.6;      // slow drifting turbulence
+    float st   = T + flow;
 
-    // Subtle film grain (very low amplitude so it doesn't overwhelm the field)
-    float grain = vnoise(gl_FragCoord.xy * 0.9 + uTime * 12.0) * 0.025;
+    uv.x += 1.20 * cos(0.50 * uv.y + st);
+    uv.y += 0.60 * cos(1.40 * uv.x + st);
+    uv.x += 0.60 * cos(1.00 * uv.y + st * 1.2);
+    uv.y += 0.30 * cos(2.80 * uv.x + st * 1.2);
+    uv.x += 0.40 * cos(1.50 * uv.y + st * 1.5);
+    uv.y += 0.20 * cos(4.20 * uv.x + st * 1.5);
+    uv.x += 0.30 * cos(2.00 * uv.y + st * 1.9);
+    uv.y += 0.15 * cos(5.60 * uv.x + st * 1.9);
+    uv.x += 0.24 * cos(2.50 * uv.y + st * 2.3);
+    uv.y += 0.12 * cos(7.00 * uv.x + st * 2.3);
 
-    float luminosity = abs(sin(slowedTime - uv.y - uv.x));
-    float base = min(0.04 / luminosity + min(grain * (0.06 / luminosity), 0.1), 1.0);
+    // ---------------------------------------------------------------------
+    // Luminosity — slightly softer division, gentler floor
+    // ---------------------------------------------------------------------
+    // CSS-pixel coords derived from vUv + iResolution (DPR-independent)
+    vec2 pxCSS = vUv * iResolution.xy;
+    float grain = vnoise(pxCSS * 0.9 + uTime * 12.0) * 0.022;
 
-    // Soft vignette so corners are deeper than center
-    vec2 ndc = (gl_FragCoord.xy / iResolution.xy) * 2.0 - 1.0;
-    float vignette = 1.0 - dot(ndc, ndc) * 0.18;
+    float lumA = abs(sin(T - uv.y - uv.x));
+    float lumB = abs(sin(T * 0.9 + (uv.x + uv.y) * 0.6)); // secondary wave
+    float luminosity = mix(lumA, lumB, 0.3) + 0.015;
+
+    float base = 0.045 / luminosity + grain * (0.06 / luminosity);
+    base = min(base, 1.0);
+
+    // Soft vignette — deeper in corners, neutral at center
+    vec2 ndc = vUv * 2.0 - 1.0;
+    float vignette = 1.0 - dot(ndc, ndc) * 0.22;
     base *= vignette;
 
     base += totalGlow;
 
-    // Slightly warm the highlights to give depth without losing the monochrome feel
-    vec3 col = vec3(base);
-    col += vec3(0.015, 0.01, 0.0) * smoothstep(0.3, 0.9, base);
+    // ---------------------------------------------------------------------
+    // Color grading — two-stop cinematic ramp (deep blue → warm cream)
+    // Still looks near-monochrome but has a subtle temperature swing.
+    // ---------------------------------------------------------------------
+    vec3 shadowTint    = vec3(0.012, 0.018, 0.030); // cool blue in the lows
+    vec3 midTint       = vec3(1.000, 1.000, 1.000); // neutral mid
+    vec3 highlightTint = vec3(1.050, 1.010, 0.960); // warm cream at peaks
 
-    // --- Twinkling stars, only in darker regions so they never fight the field ---
-    vec2 starUv = gl_FragCoord.xy * 0.003;
-    vec2 starCell = floor(starUv);
-    vec2 starF = fract(starUv);
-    float starSeed = hash12(starCell);
-    if (starSeed > 0.985) {
-        float star = smoothstep(0.05, 0.0, length(starF - 0.5));
-        float twinkle = 0.5 + 0.5 * sin(uTime * (1.5 + starSeed * 4.0) + starSeed * 10.0);
-        float mask = smoothstep(0.16, 0.02, base); // only in dark zones
-        col += vec3(star * twinkle * 0.35 * mask);
+    float low  = smoothstep(0.00, 0.25, base);
+    float high = smoothstep(0.35, 0.95, base);
+
+    vec3 col = mix(shadowTint, midTint, low) * base;
+    col = mix(col, highlightTint * base, high);
+
+    // Apply cursor / ripple colored glow on top
+    col += glowTint;
+
+    // ---------------------------------------------------------------------
+    // Starfield — two layers (tiny pinpricks + occasional bigger stars)
+    // Only appears in dark zones so it never fights the field.
+    // ---------------------------------------------------------------------
+    float darkMask = smoothstep(0.18, 0.03, base);
+
+    // Layer 1: dense small stars
+    {
+        vec2 grid = pxCSS * 0.005;
+        vec2 cell = floor(grid);
+        vec2 frac = fract(grid);
+        float seed = hash12(cell);
+        if (seed > 0.975) {
+            vec2  jitter = hash22(cell) * 0.6 + 0.2;
+            float d      = length(frac - jitter);
+            float star   = smoothstep(0.06, 0.0, d);
+            float tw     = 0.45 + 0.55 * sin(uTime * (1.0 + seed * 3.0) + seed * 10.0);
+            col += vec3(0.22, 0.24, 0.30) * star * tw * darkMask;
+        }
     }
 
-    // 8-bit anti-banding dither — randomised triangular noise, amplitude ~1/255
-    float dither = (hash12(gl_FragCoord.xy + mod(uTime, 1.0)) - 0.5) * (1.0 / 255.0);
+    // Layer 2: sparse bigger stars with a soft colored halo
+    {
+        vec2 grid = pxCSS * 0.0018;
+        vec2 cell = floor(grid);
+        vec2 frac = fract(grid);
+        float seed = hash12(cell + 17.0);
+        if (seed > 0.988) {
+            vec2  jitter = hash22(cell + 3.0) * 0.6 + 0.2;
+            float d      = length(frac - jitter);
+            float core   = smoothstep(0.035, 0.0, d);
+            float halo   = smoothstep(0.22, 0.0, d) * 0.35;
+            float tw     = 0.5 + 0.5 * sin(uTime * (0.6 + seed * 2.5));
+            vec3  tint   = mix(vec3(0.55, 0.60, 0.80), vec3(0.80, 0.65, 0.55),
+                               fract(seed * 7.0));
+            col += (core + halo) * tint * tw * darkMask;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Final contrast & dither
+    // ---------------------------------------------------------------------
+    // Gentle contrast curve — lifts mids slightly without washing out the black
+    col = mix(col, col * (0.6 + col * 1.2), 0.65);
+
+    // 8-bit anti-banding dither
+    float dither = (hash12(pxCSS + mod(uTime, 1.0)) - 0.5) * (1.0 / 255.0);
     col += dither;
 
     gl_FragColor.rgb = col;
-    gl_FragColor.a = 1.0;
+    gl_FragColor.a   = 1.0;
 }


### PR DESCRIPTION
## Summary

A long pass of iterative polish on top of the current business-card site. The visual language is preserved — 3D text + animated shader background + minimal typographic UI — but just about every layer got tightened.

### Content (from the CV)
- Fix contact email: `appxpy@appxpy.com` → `me@appxpy.com`
- Add GitHub link to the footer contact nav
- New **About** overlay (press `I` or tap the top-right button) with experience at VK / Yandex / LANIT, selected projects (Sphere, NFFS, Speech2Text), skills, education, keyboard shortcuts, and "elsewhere" links — all sourced from the CV
- Footer shows a quiet "Currently · Go Engineer at VK · Moscow" line
- Year derived from `new Date().getFullYear()` instead of hard-coded 2026

### Mobile
- Header items now stack in natural reading order (Day → Logo → Download CV); the old `order-2` hack is gone
- New mobile top bar: `appxpy.com` wordmark on the left, `About ↗` on the right, consistently aligned
- Long-press-to-About gesture removed (too easy to trigger accidentally)
- Safe-area insets respected on iOS (top bar + nav + About panel)
- Contact links shrink slightly on very small screens so nothing wraps
- `tabular-nums` on day/time so they don't jitter

### Shader / visuals
- Coordinate system reworked to use `vUv + iResolution` so fragment, mouse, and click positions all agree (previous code had a DPR mismatch)
- 3-octave FBM modulates the fluid-field phase for drift and depth
- Subtle two-stop cinematic color grade (deep blue shadows → warm cream peaks) while staying near-monochrome
- Two-layer starfield: dense small pinpricks + sparse bigger stars with jittered positions and soft colored halos
- Cursor halo pulses; click ripples emit a cool chromatic bloom with a trailing wake
- Anti-banding dither, vignette, secondary luminosity wave
- Fluid-field loop unrolled; value-noise grain
- 3D name now has a subtle breathing float
- WebGL fallback renders a clean static card if the context is lost

### Accessibility
- Global `:focus-visible` ring, skip-to-contact link
- Proper `<nav>`, `<main>`, `<footer>`, aria-labels; `aria-hidden` on the decorative canvas
- Focus trap + `Esc` + focus restoration inside the About dialog
- `prefers-reduced-motion` honoured everywhere (shader, title flicker, CSS transitions)
- Skip-to-contact link surfaces on first Tab

### Performance
- Bundle split: app ~11 kB, vendor ~78 kB, three ~194 kB gzipped
- Font preloads (variable font + Three.js text atlases) and CV prefetch on hover/focus/touch
- Canvas `frameloop` drops to `demand` when the tab is hidden or `prefers-reduced-motion`
- Title animation + clock interval pause while the tab is hidden
- In-place ripple pruning, `clock.elapsedTime` instead of per-frame `new Date()`
- Fixed stale-closure bug where `iResolution` / `uDpr` uniforms never updated after resize
- `_headers` file: immutable cache for hashed assets and fonts, plus security headers (nosniff / X-Frame-Options / Referrer-Policy / Permissions-Policy)
- `npm audit fix` applied (cross-spawn + @babel/runtime advisories resolved)

### SEO / social
- Rich meta tags, canonical URL, JSON-LD `Person` with jobTitle / worksFor / alumniOf / sameAs
- `robots.txt`, `sitemap.xml`, `humans.txt`, PWA `manifest.webmanifest`
- Branded `404.html`
- Generated a proper 1200×630 `preview.png` OG image with `og:image:width/height/alt`
- `<noscript>` fallback with contact links

### Interactions
- Keyboard shortcuts: `I` (toggle About), `Esc` (close), `Space` / `R` (spawn random ripple)
- Transient keyboard-hint pill surfaces on load and dismisses on first interaction
- Click email to copy it to clipboard (mailto: still fires)
- Animated underline refactored into a shared `navLinkClass` constant
- Projects in About link to github.com/appxpy with hover state

## Test plan

- [ ] `npm run build` produces the chunked bundle without warnings
- [ ] Homepage renders with shader and 3D text
- [ ] `robots.txt`, `sitemap.xml`, `manifest.webmanifest`, `humans.txt`, `preview.png`, `404.html`, `resume.pdf` all serve with 200s
- [ ] Press `I` → About slides in; `Esc` closes it; Tab cycles inside; focus returns to the trigger
- [ ] Click the download CV button → `resume.pdf` opens in a new tab
- [ ] Click on the background → ripple spawns; `Space`/`R` also spawns ripples
- [ ] Resize the window → shader stretches correctly, header/footer reflow without overlap
- [ ] Mobile layout (≤ 425px): top bar shows `appxpy.com` + `About ↗`; header stacks Day → Logo → CV; contacts and footer don't overlap
- [ ] `prefers-reduced-motion: reduce` → shader calms down, title stops flickering, transitions shortened
- [ ] Lighthouse sanity-check (a11y, SEO, best-practices)
