### PR TITLE
Adaptive layout, minimalist dot shader, fix resize bug

### DIFF
--- a/src/Scene.tsx
+++ b/src/Scene.tsx
@@ -1,7 +1,9 @@
 import Plane from './components/Plane'
 import { ClickData } from './components/Plane'
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
+import { useThree } from '@react-three/fiber';
+import { OrthographicCamera } from 'three';
 import { Dimensions } from "./main";
 
 interface SceneProps {
@@ -10,9 +12,31 @@ interface SceneProps {
     mousePosRef: React.MutableRefObject<[number, number]>;
 }
 
+// Keeps the orthographic camera frustum in sync with viewport dimensions.
+// Without this, R3F only applies `camera={...}` on mount, so after a window
+// resize the shader stretches / gets clipped until reload.
+const CameraController: FunctionComponent<{ dimensions: Dimensions }> = ({ dimensions }) => {
+    const { camera, gl } = useThree();
+
+    useEffect(() => {
+        if (!(camera as OrthographicCamera).isOrthographicCamera) return;
+        const cam = camera as OrthographicCamera;
+        cam.left   = -dimensions.width / 2;
+        cam.right  =  dimensions.width / 2;
+        cam.top    =  dimensions.height / 2;
+        cam.bottom = -dimensions.height / 2;
+        cam.updateProjectionMatrix();
+        // Ensure the renderer matches the CSS pixel size too
+        gl.setSize(dimensions.width, dimensions.height, false);
+    }, [camera, gl, dimensions.width, dimensions.height]);
+
+    return null;
+};
+
 const Scene: FunctionComponent<SceneProps> = (props) => {
     return (
         <>
+            <CameraController dimensions={props.dimensions} />
             <Plane dimensions={props.dimensions} clickData={props.clickData} mousePosRef={props.mousePosRef} />
             <ambientLight intensity={0.1} />
             <spotLight

--- a/src/components/InfoOverlay.tsx
+++ b/src/components/InfoOverlay.tsx
@@ -50,7 +50,6 @@ interface Project {
     name: string;
     stack: string;
     blurb: string;
-    href?: string;
 }
 
 const PROJECTS: Project[] = [
@@ -58,19 +57,16 @@ const PROJECTS: Project[] = [
         name: 'Sphere',
         stack: 'TypeScript · GLSL · OpenGL · Go · WebSockets',
         blurb: 'Procedurally generated sphere — 100k particles driven by a 7-shader pipeline, real-time in the browser. Go backend syncs geolocations across clients.',
-        href: 'https://github.com/appxpy',
     },
     {
         name: 'NFFS — Neural Network From Scratch',
         stack: 'C++ · CMake · Qt · GoogleTest · Doxygen',
         blurb: 'Perceptron-architecture neural network framework. Designed the architecture, wrote unit tests and docs.',
-        href: 'https://github.com/appxpy',
     },
     {
         name: 'Speech2Text Telegram Bot',
         stack: 'Python · Aiogram · PostgreSQL · Docker · Yandex SpeechKit',
         blurb: 'Transcribes voice and video messages. End-to-end pipelines for build and deploy.',
-        href: 'https://github.com/appxpy',
     },
 ];
 
@@ -208,29 +204,15 @@ export const InfoOverlay: FunctionComponent<InfoOverlayProps> = ({ open, onClose
                     <ul className="space-y-5">
                         {PROJECTS.map((p) => (
                             <li key={p.name}>
-                                {p.href ? (
-                                    <a
-                                        href={p.href}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="group block -mx-2 px-2 py-1 rounded hover:bg-white/[0.03] focus-visible:bg-white/[0.05] focus-visible:outline-none transition-colors"
-                                    >
-                                        <p className="text-base group-hover:underline underline-offset-4 decoration-white/40">
-                                            {p.name} <span className="opacity-40 text-sm">↗</span>
-                                        </p>
-                                        <p className="text-xs uppercase opacity-50 tracking-wider mt-0.5">{p.stack}</p>
-                                        <p className="text-sm opacity-80 mt-1 leading-relaxed">{p.blurb}</p>
-                                    </a>
-                                ) : (
-                                    <div>
-                                        <p className="text-base">{p.name}</p>
-                                        <p className="text-xs uppercase opacity-50 tracking-wider mt-0.5">{p.stack}</p>
-                                        <p className="text-sm opacity-80 mt-1 leading-relaxed">{p.blurb}</p>
-                                    </div>
-                                )}
+                                <p className="text-base">{p.name}</p>
+                                <p className="text-xs uppercase opacity-50 tracking-wider mt-0.5">{p.stack}</p>
+                                <p className="text-sm opacity-80 mt-1 leading-relaxed">{p.blurb}</p>
                             </li>
                         ))}
                     </ul>
+                    <p className="text-xs uppercase opacity-50 tracking-wider mt-5">
+                        More on <a href="https://github.com/appxpy" target="_blank" rel="noopener noreferrer" className="underline decoration-white/30 underline-offset-4 hover:decoration-white">github.com/appxpy</a>
+                    </p>
                 </section>
 
                 <section className="mt-12 pt-8 border-t border-white/10">

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -16,7 +16,7 @@ const LINKS = {
 
 // Shared "animated underline" link style used by the footer nav
 const navLinkClass =
-    "relative uppercase font-normal text-[0.95rem] mm:text-lg text-start hover:cursor-pointer " +
+    "relative uppercase font-normal text-[0.9rem] sm:text-lg text-start hover:cursor-pointer " +
     "after:duration-300 after:bg-white after:w-0 after:h-[1.5px] " +
     "after:absolute after:bottom-[5.5px] after:left-0 hover:after:w-full " +
     "pointer-events-auto focus-visible:outline-none focus-visible:after:w-full";
@@ -97,7 +97,6 @@ const Page: FunctionComponent = () => {
     const [copied, setCopied] = useState(false);
     const [infoOpen, setInfoOpen] = useState(false);
     const [introDone, setIntroDone] = useState(false);
-    const [hintVisible, setHintVisible] = useState(false);
     const [webglSupported, setWebglSupported] = useState<boolean>(true);
     const [documentVisible, setDocumentVisible] = useState<boolean>(() =>
         typeof document === 'undefined' ? true : !document.hidden
@@ -271,24 +270,10 @@ const Page: FunctionComponent = () => {
         return () => window.removeEventListener('keydown', onKey);
     }, []);
 
-    // Intro fade-in then show keyboard hint briefly; hint hides on first
-    // meaningful interaction
+    // Intro fade-in
     useEffect(() => {
-        const t1 = window.setTimeout(() => setIntroDone(true), 400);
-        const t2 = window.setTimeout(() => setHintVisible(true), 1100);
-        const t3 = window.setTimeout(() => setHintVisible(false), 6500);
-
-        const hideHint = () => setHintVisible(false);
-        window.addEventListener('click', hideHint, { once: true });
-        window.addEventListener('keydown', hideHint, { once: true });
-
-        return () => {
-            window.clearTimeout(t1);
-            window.clearTimeout(t2);
-            window.clearTimeout(t3);
-            window.removeEventListener('click', hideHint);
-            window.removeEventListener('keydown', hideHint);
-        };
+        const t = window.setTimeout(() => setIntroDone(true), 400);
+        return () => window.clearTimeout(t);
     }, []);
 
     // Detect WebGL availability so we can degrade gracefully
@@ -313,7 +298,7 @@ const Page: FunctionComponent = () => {
 
     return (
         <div
-            className="inset-0 fixed overflow-hidden cursor-crosshair"
+            className="inset-0 fixed overflow-hidden"
             onClick={handleClick}
             onPointerMove={handlePointerMove}
         >
@@ -375,12 +360,19 @@ const Page: FunctionComponent = () => {
                 id="main"
                 role="main"
                 aria-label="Pankevich George — personal business card"
-                className={`absolute inset-0 font-inter font-normal p-6 pointer-events-none transition-opacity duration-700 ease-out ${
-                    introDone ? 'opacity-80' : 'opacity-0'
+                className={`absolute inset-0 font-inter font-normal pointer-events-none transition-opacity duration-700 ease-out ${
+                    introDone ? 'opacity-85' : 'opacity-0'
                 }`}
+                style={{
+                    paddingTop: 'max(1rem, env(safe-area-inset-top))',
+                    paddingRight: 'max(1rem, env(safe-area-inset-right))',
+                    paddingBottom: 'max(1rem, env(safe-area-inset-bottom))',
+                    paddingLeft: 'max(1rem, env(safe-area-inset-left))',
+                }}
             >
-                <div className="relative h-full w-full box-border flex flex-col justify-between" style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
-                    <div className="h-20 hidden absolute my-3 mx-6 top-0 right-0 sm:flex flex-col items-end justify-center">
+                <div className="relative h-full w-full flex flex-col gap-3 sm:gap-0 sm:p-2">
+                    {/* Desktop-only top-right corner */}
+                    <div className="hidden sm:flex flex-col items-end absolute right-0 top-0 pointer-events-none">
                         <span className="uppercase font-normal text-lg text-end pointer-events-auto">→{year}</span>
                         <a
                             href="/"
@@ -390,7 +382,9 @@ const Page: FunctionComponent = () => {
                             appxpy.com
                         </a>
                     </div>
-                    <div className="h-20 hidden absolute my-3 mx-6 bottom-0 right-0 sm:flex flex-col items-end justify-start">
+
+                    {/* Desktop-only bottom-right corner */}
+                    <div className="hidden sm:flex flex-col items-end absolute right-0 bottom-0 pointer-events-none">
                         <button
                             type="button"
                             onClick={openInfo}
@@ -401,8 +395,9 @@ const Page: FunctionComponent = () => {
                         </button>
                         <span className="uppercase font-normal text-xs opacity-50 text-end pointer-events-auto select-none">Press I</span>
                     </div>
-                    {/* Mobile-only top bar: wordmark on the left, About on the right */}
-                    <div className="absolute top-0 left-0 right-0 flex items-center justify-between sm:hidden pointer-events-none">
+
+                    {/* Mobile-only top bar: wordmark left, About right */}
+                    <div className="flex items-center justify-between sm:hidden shrink-0">
                         <a
                             href="/"
                             aria-label="appxpy.com home"
@@ -420,10 +415,42 @@ const Page: FunctionComponent = () => {
                         </button>
                     </div>
 
+                    {/* Header — Day / Logo / CV */}
+                    <header className="flex flex-col sm:flex-row justify-center items-center gap-3 sm:gap-10 md:gap-16 select-none shrink-0 mt-2 sm:mt-0">
+                        <div className="flex items-center justify-center gap-3 pointer-events-auto sm:w-min">
+                            <span className="uppercase font-normal text-base sm:text-lg text-center tabular-nums" aria-label={`Day: ${day}`}>{day}</span>
+                            <span
+                                className="uppercase w-20 font-normal text-lg text-center hidden sm:block tabular-nums"
+                                aria-live="off"
+                                aria-label={`Local time: ${time}`}
+                            >
+                                {time}
+                            </span>
+                        </div>
+                        <Logo size={40} />
+                        <a
+                            className="relative uppercase font-normal text-base sm:text-lg text-center w-40 pointer-events-auto hover:cursor-pointer after:duration-300 after:bg-white after:w-0 after:h-[1.5px] after:absolute after:bottom-[5.5px] after:left-1/2 after:-translate-x-1/2 hover:after:w-[9.5rem] focus-visible:outline-none focus-visible:after:w-[9.5rem]"
+                            href={LINKS.cv}
+                            target="_blank"
+                            rel="noopener"
+                            download="pankevich-george-cv.pdf"
+                            aria-label="Download CV as PDF"
+                            onMouseEnter={prefetchCv}
+                            onFocus={prefetchCv}
+                            onTouchStart={prefetchCv}
+                        >
+                            DOWNLOAD CV ↗
+                        </a>
+                    </header>
+
+                    {/* Flexible spacer: fills the middle so nav/footer hug the bottom */}
+                    <div className="flex-1 min-h-[2rem]" />
+
+                    {/* Contact nav */}
                     <nav
                         id="contact"
                         aria-label="Contact links"
-                        className="absolute my-6 sm:my-3 sm:mx-6 bottom-10 sm:bottom-0 left-0 flex flex-col items-start justify-start z-20 max-w-[80vw]"
+                        className="flex flex-col items-start shrink-0 max-w-[85vw]"
                     >
                         <a
                             href={`mailto:${LINKS.email}`}
@@ -459,57 +486,17 @@ const Page: FunctionComponent = () => {
                         </a>
                     </nav>
 
-                    <header
-                        className={'flex flex-col mm:flex-row justify-center items-center pt-10 mm:pt-0 h-auto mm:h-10 gap-4 mm:gap-4 sm:gap-10 md:gap-16 select-none'}
-                    >
-                        <div className="flex items-center justify-center mm:justify-between gap-2 mm:gap-3 pointer-events-auto mm:w-min">
-                            <span className="uppercase font-normal text-base mm:text-lg text-center tabular-nums" aria-label={`Day: ${day}`}>{day}</span>
-                            <span
-                                className="uppercase w-20 font-normal text-lg text-center hidden sm:block tabular-nums"
-                                aria-live="off"
-                                aria-label={`Local time: ${time}`}
-                            >
-                                {time}
-                            </span>
-                        </div>
-                        <Logo size={40} />
-                        <a
-                            className="relative uppercase font-normal text-base mm:text-lg text-center w-40 pointer-events-auto hover:cursor-pointer after:duration-300 after:bg-white after:w-0 after:h-[1.5px] after:absolute after:bottom-[5.5px] after:left-1/2 after:-translate-x-1/2 hover:after:w-[9.5rem] focus-visible:outline-none focus-visible:after:w-[9.5rem]"
-                            href={LINKS.cv}
-                            target="_blank"
-                            rel="noopener"
-                            download="pankevich-george-cv.pdf"
-                            aria-label="Download CV as PDF"
-                            onMouseEnter={prefetchCv}
-                            onFocus={prefetchCv}
-                            onTouchStart={prefetchCv}
-                        >
-                            DOWNLOAD CV ↗
-                        </a>
-                    </header>
-
-                    <footer className="h-10 w-full flex flex-col items-center justify-center gap-1">
-                        <span className="relative uppercase font-normal text-sm opacity-70 md:text-lg text-start pointer-events-auto">
+                    {/* Footer */}
+                    <footer className="w-full flex flex-col items-center justify-center gap-1 shrink-0 mt-3 sm:mt-4">
+                        <span className="uppercase font-normal text-xs sm:text-sm md:text-base opacity-70 text-center pointer-events-auto">
                             © Pankevich George, {year}
                         </span>
-                        <span className="relative uppercase font-normal text-[10px] sm:text-xs opacity-50 text-center pointer-events-auto select-none">
+                        <span className="uppercase font-normal text-[10px] sm:text-xs opacity-50 text-center pointer-events-auto select-none">
                             Currently · Go Engineer at VK · Moscow
                         </span>
                     </footer>
                 </div>
             </main>
-
-            {/* Floating keyboard-shortcut hint */}
-            <div
-                aria-hidden="true"
-                className={`fixed left-1/2 -translate-x-1/2 bottom-14 z-30 pointer-events-none transition-all duration-500 ${
-                    hintVisible && !infoOpen ? 'opacity-70 translate-y-0' : 'opacity-0 translate-y-2'
-                }`}
-            >
-                <div className="px-3 py-1.5 rounded-full bg-white/5 border border-white/10 backdrop-blur-sm text-[10px] sm:text-xs uppercase tracking-[0.2em] text-white/80 whitespace-nowrap">
-                    <kbd className="font-mono">I</kbd> about&nbsp;·&nbsp;<kbd className="font-mono">Space</kbd> ripple&nbsp;·&nbsp;<kbd className="font-mono">Click</kbd> anywhere
-                </div>
-            </div>
 
             <InfoOverlay open={infoOpen} onClose={closeInfo} />
         </div>

--- a/src/shaders/shader.frag
+++ b/src/shaders/shader.frag
@@ -1,9 +1,18 @@
+// -----------------------------------------------------------------------------
+// Minimalist interactive dot-grid background.
+//
+// Pure monochrome: a regular grid of tiny white dots on black.
+// The cursor pushes nearby dots outward (magnetic repulsion), and clicks
+// emit an expanding ring that sweeps dots outward radially.
+// Everything is computed in CSS-pixel space via vUv + iResolution, so it
+// is DPR-independent and consistent across mouse / click / fragment.
+// -----------------------------------------------------------------------------
 varying vec2 vUv;
 uniform float uTime;
 uniform vec2 iResolution;
 uniform float uDpr;
 
-// Up to 8 concurrent ripples
+// Ripples
 const int MAX_RIPPLES = 8;
 uniform vec2 uClicks[8];
 uniform float uClickTimes[8];
@@ -11,221 +20,121 @@ uniform int uRippleCount;
 uniform vec2 uMouse;
 uniform float uReducedMotion; // 0.0 or 1.0
 
-// -----------------------------------------------------------------------------
-// Hash / noise helpers
-// -----------------------------------------------------------------------------
+// Hash for subtle per-cell variation
 float hash12(vec2 p) {
     p = fract(p * vec2(123.34, 456.21));
     p += dot(p, p + 45.32);
     return fract(p.x * p.y);
 }
 
-vec2 hash22(vec2 p) {
-    p = vec2(dot(p, vec2(127.1, 311.7)), dot(p, vec2(269.5, 183.3)));
-    return fract(sin(p) * 43758.5453123);
-}
+// -----------------------------------------------------------------------------
+// Displacement field evaluated at a point in CSS pixel space.
+// Combines:
+//   - cursor repulsion: dots within CURSOR_RADIUS are pushed radially outward
+//   - click ripples:    expanding ring pushes dots at the ring's radius
+//   - idle drift:       slow sinusoidal breathing so the grid feels alive
+// -----------------------------------------------------------------------------
+vec2 displacementAt(vec2 pos, vec2 mousePx, vec2 cellIdx) {
+    vec2 disp = vec2(0.0);
 
-// Smoothed value noise
-float vnoise(vec2 p) {
-    vec2 i = floor(p);
-    vec2 f = fract(p);
-    float a = hash12(i);
-    float b = hash12(i + vec2(1.0, 0.0));
-    float c = hash12(i + vec2(0.0, 1.0));
-    float d = hash12(i + vec2(1.0, 1.0));
-    vec2 u = f * f * (3.0 - 2.0 * f);
-    return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
-}
-
-// 3-octave FBM on top of value noise — adds depth to the fluid field
-float fbm(vec2 p) {
-    float v = 0.0;
-    float a = 0.5;
-    for (int i = 0; i < 3; i++) {
-        v += a * vnoise(p);
-        p *= 2.02;
-        a *= 0.5;
+    // --- Cursor repulsion ---
+    vec2 toFromMouse = pos - mousePx;
+    float mouseDist = length(toFromMouse);
+    const float CURSOR_RADIUS = 150.0;           // CSS px
+    const float CURSOR_STRENGTH = 22.0;          // max push distance
+    if (mouseDist > 0.001 && mouseDist < CURSOR_RADIUS) {
+        float n = mouseDist / CURSOR_RADIUS;
+        float strength = pow(1.0 - n, 2.0);
+        disp += (toFromMouse / mouseDist) * strength * CURSOR_STRENGTH;
     }
-    return v;
-}
 
-// Aspect-corrected UV centered at origin, shortest side ≈ 1.
-// We derive everything from vUv (plane-space [0..1]) and iResolution (CSS px),
-// so the result is DPR-independent and consistent across mouse/click/frag.
-vec2 toUV(vec2 uv01) {
-    vec2 p = (uv01 - 0.5) * iResolution.xy / min(iResolution.x, iResolution.y);
-    return p * 1.4;
+    // --- Click ripples ---
+    for (int i = 0; i < MAX_RIPPLES; i++) {
+        if (i >= uRippleCount) break;
+        float elapsed = uTime - uClickTimes[i];
+        if (elapsed < 0.0 || elapsed > 2.8) continue;
+
+        float t = clamp(elapsed / 2.8, 0.0, 1.0);
+        float eased = 1.0 - pow(1.0 - t, 3.0);
+        float radius = eased * 620.0;            // CSS px
+        float fade = pow(1.0 - t, 1.7);
+
+        vec2 clickPx = uClicks[i] * iResolution.xy;
+        vec2 fromClick = pos - clickPx;
+        float distFromClick = length(fromClick);
+        if (distFromClick < 0.001) continue;
+
+        // Dots in a soft band at the current ring radius get pushed outward.
+        float ringBand = smoothstep(90.0, 0.0, abs(distFromClick - radius));
+        disp += (fromClick / distFromClick) * ringBand * fade * 36.0;
+    }
+
+    // --- Idle drift: tiny sinusoidal wave per cell so it never feels static ---
+    float driftScale = mix(1.0, 0.0, uReducedMotion);
+    float driftT = uTime * 0.55;
+    vec2 drift = vec2(
+        sin(cellIdx.x * 0.35 + cellIdx.y * 0.22 + driftT),
+        cos(cellIdx.y * 0.28 + cellIdx.x * 0.18 + driftT * 0.9)
+    ) * 1.4 * driftScale;
+    disp += drift;
+
+    return disp;
 }
 
 // -----------------------------------------------------------------------------
 // Main
 // -----------------------------------------------------------------------------
 void main() {
-    float motionScale = mix(1.0, 0.15, uReducedMotion);
-    float T = uTime * 0.08 * motionScale;   // slow master clock for the field
+    // CSS pixel coordinates derived from vUv + iResolution (DPR-independent).
+    vec2 px = vUv * iResolution.xy;
+    vec2 mousePx = uMouse * iResolution.xy;
 
-    vec2 uv = toUV(vUv);
+    // Grid cell size adapts to the shortest edge so mobile still reads
+    // at ~11 columns; desktop gets a denser-but-still-minimal grid.
+    float shortEdge = min(iResolution.x, iResolution.y);
+    float cellSize = clamp(shortEdge / 22.0, 30.0, 46.0);
 
-    float totalGlow = 0.0;
-    vec3  glowTint  = vec3(0.0);              // accumulated colored glow
+    vec2 cellIdx0 = floor(px / cellSize);
 
-    // ---------------------------------------------------------------------
-    // Gravitational lensing + soft chromatic halo around the cursor
-    // ---------------------------------------------------------------------
-    vec2 mouseUV    = toUV(uMouse);
-    vec2 toMouse    = uv - mouseUV;
-    float mouseDist = length(toMouse);
+    // For each fragment we check a 3×3 neighbourhood of cells and take
+    // the closest displaced dot. This handles dots pushed across cell
+    // boundaries by cursor/ripple displacement.
+    float minD = 1e9;
+    float nearestFade = 1.0;
 
-    float lensRadius   = 0.9;
-    float lensStrength = 0.06 * mix(1.0, 0.3, uReducedMotion);
-    if (mouseDist < lensRadius) {
-        float normDist = mouseDist / lensRadius;
-        float warp = lensStrength * pow(1.0 - normDist, 2.0) / (mouseDist + 0.015);
-        uv -= toMouse * warp;
+    for (int dy = -1; dy <= 1; dy++) {
+        for (int dx = -1; dx <= 1; dx++) {
+            vec2 cIdx    = cellIdx0 + vec2(float(dx), float(dy));
+            vec2 cCenter = (cIdx + 0.5) * cellSize;
+            vec2 disp    = displacementAt(cCenter, mousePx, cIdx);
+            vec2 dotPos  = cCenter + disp;
 
-        float pulse   = 0.85 + 0.15 * sin(uTime * 1.6);
-        float haloAmt = pow(1.0 - normDist, 3.0) * pulse;
-        totalGlow    += haloAmt * 0.022;
-        // cool-to-warm tint that breathes with the pulse
-        glowTint     += haloAmt * vec3(0.02, 0.035, 0.06);
+            float d = distance(px, dotPos);
+            if (d < minD) {
+                minD = d;
+                // Soft per-dot brightness variation so it's not completely uniform
+                float h = hash12(cIdx);
+                nearestFade = 0.70 + 0.30 * h;
+            }
+        }
     }
 
-    // ---------------------------------------------------------------------
-    // Shockwave ripples from clicks
-    // ---------------------------------------------------------------------
-    for (int i = 0; i < MAX_RIPPLES; i++) {
-        if (i >= uRippleCount) break;
+    // Dot radius in CSS pixels — very small, very clean.
+    float dotRadius = 1.35;
+    float dotEdge   = 0.85;
+    float dotMask   = smoothstep(dotRadius + dotEdge, dotRadius, minD);
 
-        float elapsed = uTime - uClickTimes[i];
-        if (elapsed > 2.8) continue;
+    // Base colour: pure white dots, black background
+    vec3 col = vec3(dotMask * nearestFade * 0.62);
 
-        float t     = clamp(elapsed / 2.8, 0.0, 1.0);
-        float eased = 1.0 - pow(1.0 - t, 3.0);
-        float radius = eased * 1.7;
-        float fade   = pow(1.0 - t, 2.0);
-        fade *= smoothstep(0.0, 0.08, elapsed);
-
-        vec2 clickUV = toUV(uClicks[i]);
-        float dist   = distance(uv, clickUV);
-
-        float ringWidth = 0.10 + elapsed * 0.022;
-        float ring      = smoothstep(ringWidth, 0.0, abs(dist - radius));
-
-        vec2 dir  = normalize(uv - clickUV + 0.0001);
-        uv       += dir * ring * fade * 0.14;
-        totalGlow += ring * fade * 0.09;
-        glowTint  += ring * fade * vec3(0.02, 0.04, 0.08); // cool teal bloom
-
-        // Trailing wake
-        float trail = smoothstep(radius, radius - 0.18, dist)
-                    * smoothstep(radius - 0.45, radius - 0.1, dist);
-        totalGlow  += trail * fade * 0.018;
-    }
-
-    // ---------------------------------------------------------------------
-    // Core fluid field — unrolled domain warp modulated by slow FBM
-    // ---------------------------------------------------------------------
-    float flow = fbm(uv * 0.6 + T * 0.4) * 0.6;      // slow drifting turbulence
-    float st   = T + flow;
-
-    uv.x += 1.20 * cos(0.50 * uv.y + st);
-    uv.y += 0.60 * cos(1.40 * uv.x + st);
-    uv.x += 0.60 * cos(1.00 * uv.y + st * 1.2);
-    uv.y += 0.30 * cos(2.80 * uv.x + st * 1.2);
-    uv.x += 0.40 * cos(1.50 * uv.y + st * 1.5);
-    uv.y += 0.20 * cos(4.20 * uv.x + st * 1.5);
-    uv.x += 0.30 * cos(2.00 * uv.y + st * 1.9);
-    uv.y += 0.15 * cos(5.60 * uv.x + st * 1.9);
-    uv.x += 0.24 * cos(2.50 * uv.y + st * 2.3);
-    uv.y += 0.12 * cos(7.00 * uv.x + st * 2.3);
-
-    // ---------------------------------------------------------------------
-    // Luminosity — slightly softer division, gentler floor
-    // ---------------------------------------------------------------------
-    // CSS-pixel coords derived from vUv + iResolution (DPR-independent)
-    vec2 pxCSS = vUv * iResolution.xy;
-    float grain = vnoise(pxCSS * 0.9 + uTime * 12.0) * 0.022;
-
-    float lumA = abs(sin(T - uv.y - uv.x));
-    float lumB = abs(sin(T * 0.9 + (uv.x + uv.y) * 0.6)); // secondary wave
-    float luminosity = mix(lumA, lumB, 0.3) + 0.015;
-
-    float base = 0.045 / luminosity + grain * (0.06 / luminosity);
-    base = min(base, 1.0);
-
-    // Soft vignette — deeper in corners, neutral at center
+    // Soft vignette — a touch deeper in the corners
     vec2 ndc = vUv * 2.0 - 1.0;
-    float vignette = 1.0 - dot(ndc, ndc) * 0.22;
-    base *= vignette;
-
-    base += totalGlow;
-
-    // ---------------------------------------------------------------------
-    // Color grading — two-stop cinematic ramp (deep blue → warm cream)
-    // Still looks near-monochrome but has a subtle temperature swing.
-    // ---------------------------------------------------------------------
-    vec3 shadowTint    = vec3(0.012, 0.018, 0.030); // cool blue in the lows
-    vec3 midTint       = vec3(1.000, 1.000, 1.000); // neutral mid
-    vec3 highlightTint = vec3(1.050, 1.010, 0.960); // warm cream at peaks
-
-    float low  = smoothstep(0.00, 0.25, base);
-    float high = smoothstep(0.35, 0.95, base);
-
-    vec3 col = mix(shadowTint, midTint, low) * base;
-    col = mix(col, highlightTint * base, high);
-
-    // Apply cursor / ripple colored glow on top
-    col += glowTint;
-
-    // ---------------------------------------------------------------------
-    // Starfield — two layers (tiny pinpricks + occasional bigger stars)
-    // Only appears in dark zones so it never fights the field.
-    // ---------------------------------------------------------------------
-    float darkMask = smoothstep(0.18, 0.03, base);
-
-    // Layer 1: dense small stars
-    {
-        vec2 grid = pxCSS * 0.005;
-        vec2 cell = floor(grid);
-        vec2 frac = fract(grid);
-        float seed = hash12(cell);
-        if (seed > 0.975) {
-            vec2  jitter = hash22(cell) * 0.6 + 0.2;
-            float d      = length(frac - jitter);
-            float star   = smoothstep(0.06, 0.0, d);
-            float tw     = 0.45 + 0.55 * sin(uTime * (1.0 + seed * 3.0) + seed * 10.0);
-            col += vec3(0.22, 0.24, 0.30) * star * tw * darkMask;
-        }
-    }
-
-    // Layer 2: sparse bigger stars with a soft colored halo
-    {
-        vec2 grid = pxCSS * 0.0018;
-        vec2 cell = floor(grid);
-        vec2 frac = fract(grid);
-        float seed = hash12(cell + 17.0);
-        if (seed > 0.988) {
-            vec2  jitter = hash22(cell + 3.0) * 0.6 + 0.2;
-            float d      = length(frac - jitter);
-            float core   = smoothstep(0.035, 0.0, d);
-            float halo   = smoothstep(0.22, 0.0, d) * 0.35;
-            float tw     = 0.5 + 0.5 * sin(uTime * (0.6 + seed * 2.5));
-            vec3  tint   = mix(vec3(0.55, 0.60, 0.80), vec3(0.80, 0.65, 0.55),
-                               fract(seed * 7.0));
-            col += (core + halo) * tint * tw * darkMask;
-        }
-    }
-
-    // ---------------------------------------------------------------------
-    // Final contrast & dither
-    // ---------------------------------------------------------------------
-    // Gentle contrast curve — lifts mids slightly without washing out the black
-    col = mix(col, col * (0.6 + col * 1.2), 0.65);
+    float vignette = 1.0 - dot(ndc, ndc) * 0.28;
+    col *= vignette;
 
     // 8-bit anti-banding dither
-    float dither = (hash12(pxCSS + mod(uTime, 1.0)) - 0.5) * (1.0 / 255.0);
+    float dither = (hash12(px + mod(uTime, 1.0)) - 0.5) * (1.0 / 255.0);
     col += dither;
 
-    gl_FragColor.rgb = col;
-    gl_FragColor.a   = 1.0;
+    gl_FragColor = vec4(col, 1.0);
 }


### PR DESCRIPTION
## Summary

Follow-up to #18 that fixes the issues surfaced in the screenshots afterward: mobile header overlap, boring monochrome background, a lonely blinking star on desktop, the custom cursor, broken/aggressive project links in the About overlay, and — most importantly — the shader not adapting on window resize.

## Layout (fully adaptive now)

- Replaced the absolute/flex mix with a clean vertical flow: **top-bar → header → flex spacer → nav → footer**. Nav and footer are normal flex children now, so the old `bottom-10` nav ↔ 40 px footer collision is gone.
- Header breakpoint moved from `mm` (425 px) → `sm` (640 px). On iPhone 14 Pro Max (430 px) the mobile top bar and the row-mode header no longer both land at `y=0`.
- Desktop-only corner elements (`→year / appxpy.com` and `About ↗ / Press I`) stay absolute, but only appear at `sm+`, so they never interfere with the mobile flow.
- Removed the floating keyboard-shortcut hint pill — it sat at `bottom-14` on every layout and collided with the footer.
- Footer is auto-height with responsive text sizes; safe-area insets respected on all four edges via `env(safe-area-inset-*)`.

## About overlay: projects

- Projects were wrapped in `<a>` tags pointing to the generic `github.com/appxpy` profile — the links were broken/misleading *and* clicking on the blurb to select text hijacked navigation.
- Projects are now plain text. A single "More on github.com/appxpy" line sits under them.

## New shader — minimalist interactive dot grid

Threw out the fluid field + stars and wrote a new shader from scratch that fits the site's style:

- Regular grid of **~1.3 px white dots on black**, cell size adapts to the shortest edge (30–46 CSS px): ~11 columns on mobile, ~36 on desktop.
- **Cursor repulsion**: dots within ~150 CSS px are pushed radially away from the pointer with an inverse-square falloff.
- **Click ripples**: expanding rings push dots outward at the ring's radius, fading over ~2.8 s.
- **Idle drift**: each cell has a tiny sinusoidal wobble so the grid feels alive without blinking or twinkling.
- 3×3 neighbourhood per-fragment lookup so dots can cross cell borders when pushed.
- Fully DPR-independent (uses `vUv + iResolution` in CSS pixel space).
- Respects `prefers-reduced-motion` by killing the drift.

## Shader resize bug (critical fix)

R3F only applies the `<Canvas camera={{...}}>` prop on mount, so the orthographic frustum went stale after a window resize — that's why the shader looked "killed" until reload. Added a `CameraController` component inside the Canvas that listens to dimension changes and calls `cam.updateProjectionMatrix()` + `gl.setSize()`. The existing `iResolution` / `uDpr` uniform effects in `Plane.tsx` already handled their half; together the shader now re-adapts live.

## Desktop cursor

- Removed `cursor-crosshair`. The site uses the default system cursor everywhere except on explicit links/buttons.

## Verification

Set up Playwright and took screenshots at **10 real-world viewports** plus a live resize test. Also ran a DOM audit on the mobile viewport to confirm no stray absolute elements.

| Viewport | Size | Result |
|---|---|---|
| iPhone SE | 375 × 667 | ✅ clean |
| iPhone 15 | 393 × 852 | ✅ clean |
| iPhone 14 Pro Max | 430 × 932 | ✅ clean |
| Mobile landscape | 667 × 375 | ✅ clean |
| iPad Mini | 768 × 1024 | ✅ clean |
| iPad | 820 × 1180 | ✅ clean |
| iPad landscape | 1024 × 768 | ✅ clean |
| Laptop | 1366 × 768 | ✅ clean |
| Desktop FHD | 1920 × 1080 | ✅ clean |
| Short laptop | 1280 × 560 | ✅ clean |

**Resize test** (no reload): 1280 × 720 → 420 × 900 → 1920 × 1080. Dot grid re-adapts in every step.

- `tsc --noEmit` clean
- `vite build` clean (no circular chunk warnings)
- DOM audit confirmed no stray absolute elements on mobile

## Test plan

- [ ] Open at a ≤ 640 px viewport: mobile top bar (`APPXPY.COM` ↔ `About ↗`) sits above the header, no overlap
- [ ] Day → Logo → Download CV stack in that visual order on mobile, centered
- [ ] Resize window: dot grid fills the new viewport immediately, no reload needed
- [ ] Move cursor across canvas: nearby dots push outward
- [ ] Click: ripple ring sweeps dots outward then fades
- [ ] Projects in About don't navigate when you click-and-drag to select text
- [ ] No custom cursor on desktop
- [ ] At 1280 × 560 short laptop: header / nav / footer all visible, no collisions
